### PR TITLE
Fix generating toJson for objects with nullable enums

### DIFF
--- a/lib/src/dart_gen/json.dart
+++ b/lib/src/dart_gen/json.dart
@@ -46,6 +46,9 @@ extension on StringBuffer {
       write("'$key': $fieldName");
       final enumOptions = type.enumOptions();
       if (enumOptions != null) {
+        if (isNullable) {
+          write('?');
+        }
         write('.${enumOptions.nameProperty}');
       }
       writeln(',');

--- a/test/dart_gen/json_test.dart
+++ b/test/dart_gen/json_test.dart
@@ -37,6 +37,7 @@ const enumAbcDef = Enums(EnumValidator('EnumValue', {'abc', 'def'}));
 
 const simpleObjectWithEnum = Objects('WithEnum', {
   'myEnum': Property(enumAbcDef),
+  'myEnumButNullable': Property(Nullable(enumAbcDef)),
 });
 
 const _schemaWithDefaultValues = Objects('WithDefaults', {
@@ -191,11 +192,14 @@ import 'package:schemake/schemake.dart';
 
 class WithEnum {
   final EnumValue myEnum;
+  final EnumValue? myEnumButNullable;
   const WithEnum({
     required this.myEnum,
+    this.myEnumButNullable,
   });
   Map<String, Object?> toJson() => {
     'myEnum': myEnum.name,
+    if (myEnumButNullable != null) 'myEnumButNullable': myEnumButNullable?.name,
   };
 }
 enum EnumValue {


### PR DESCRIPTION
Just a simple fix that adds conditional member access to generated `toJson` so that [unchecked_use_of_nullable_value](https://dart.dev/diagnostics/unchecked_use_of_nullable_value) is not triggered.