### PR TITLE
Use ref for nullable nested types when useRefsForNestedTypes is enabled

### DIFF
--- a/test/json_schema/json_schema_test.dart
+++ b/test/json_schema/json_schema_test.dart
@@ -215,12 +215,14 @@ void main() {
           '"type": "object", '
           '"properties": { '
           '"myProp": { "type": "integer", "description": "my property" }, '
-          r'"otherProp": { "title": "HasDescription",'
-          r' "description": "Property description", "type": ["object", "null"],'
-          r' "properties": { "prop": { "type": "string", "description": "the prop" } },'
-          r' "required": ["prop"], "additionalProperties": false } '
-          '}, "required": ["myProp"], "additionalProperties": false'
-          ' }');
+          r'"otherProp": { "oneOf": [{ "$ref": "#/$defs/HasDescription", "description": "Property description" }, { "type": "null" }] } }, '
+          r'"required": ["myProp"], '
+          r'"additionalProperties": false, '
+          r'"$defs": { "HasDescription": { "title": "HasDescription", '
+          r'"description": "Object description", "type": "object", '
+          r'"properties": { "prop": { "type": "string", "description": "the prop" } }, '
+          r'"required": ["prop"], "additionalProperties": false } '
+          '} }');
     });
 
     test('Object with nullable property with default values', () {


### PR DESCRIPTION
Currently `Nullable(Objects(...))` generates inline object definition with additional type `null` instead of using refs when `useRefsForNestedTypes` is `true`. This leads to duplicated code and name collisions. This PR fixes it by using `oneOf` instead of appending `null` to the `type`.